### PR TITLE
Exposed more default instance methods.

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,18 +94,21 @@ ErrorCat.prototype.report = function (err) {
   rollbar.handleErrorWithPayloadData(err, { custom: (err.data || {}) }, noop);
 };
 
-/**
- * Default ErrorCat Instance.
- * @type {ErrorCat}
- */
+
+// Expose default instance methods
 var instance = new ErrorCat();
 
-/**
- * Express error responder middleware.
- * @type {function}
- */
-Object.defineProperty(ErrorCat, 'middleware', {
-  value: instance.respond.bind(instance),
-  writable: false,
-  enumerable: true
+var defaultMethods = {
+  'middleware': 'respond',
+  'create': 'create',
+  'log': 'log',
+  'report': 'report'
+};
+
+Object.keys(defaultMethods).forEach(function (name) {
+  Object.defineProperty(ErrorCat, name, {
+    value: instance[defaultMethods[name]].bind(instance),
+    writable: false,
+    enumerable: true
+  });
 });

--- a/test/error-cat.js
+++ b/test/error-cat.js
@@ -27,6 +27,30 @@ describe('ErrorCat', function() {
       }).to.throw();
       done();
     });
+
+    it('should expose an immutable create method', function(done) {
+      expect(ErrorCat.create).to.be.a.function();
+      expect(function () {
+        ErrorCat.create = 'something else';
+      }).to.throw();
+      done();
+    });
+
+    it('should expose an immutable log method', function(done) {
+      expect(ErrorCat.log).to.be.a.function();
+      expect(function () {
+        ErrorCat.log = function () {};
+      }).to.throw();
+      done();
+    });
+
+    it('should expose an immutable report method', function(done) {
+      expect(ErrorCat.report).to.be.a.function();
+      expect(function () {
+        ErrorCat.report = 22;
+      }).to.throw();
+      done();
+    });
   }); // end 'interface'
 
   describe('constructor', function() {


### PR DESCRIPTION
Exposes `create`, `log`, and `report` methods of the default instance. Going to need these for ease of use.
