### PR TITLE
create no longer reports, createAndReport reports

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ ErrorCat.prototype.canUseRollbar = function () {
 
 /**
  * Factory method that creates and logs new boom errors.
+ * Does NOT report errors - use createAndReport
+ * @param {Number} code HTTP error code for the error
  * @param {string} message Message describing the error.
  * @param {mixed} data Additional data for the error.
  * @return {Error} The error object as specified by the parameters.
@@ -49,6 +51,20 @@ ErrorCat.prototype.canUseRollbar = function () {
 ErrorCat.prototype.create = function (code, message, data) {
   var err = Boom.create(code, message, data);
   this.log(err);
+  return err;
+};
+
+/**
+ * Factory method to create AND report boom errors.
+ * Logs with debug AND reports error to rollbar (if able)
+ * @param {Number} code HTTP error code for the error
+ * @param {string} message Message describing the error.
+ * @param {mixed} data Additional data for the error.
+ * @return {Error} The error object as specified by the parameters.
+ */
+ErrorCat.prototype.createAndReport = function (code, message, data) {
+  var err = this.create(code, message, data); // calls this.log
+  this.report(err);
   return err;
 };
 
@@ -71,14 +87,14 @@ ErrorCat.prototype.respond = function (err, req, res, next) {
     err.isBoom ? err.output.payload : 'Internal Server Error'
   ));
 };
+/* jslint unused:true */
 
 /**
- * Logs errors via debug, and reports them to rollbar.
+ * Logs errors via debug
  * @param {Error} err The error to log.
  */
 ErrorCat.prototype.log = function (err) {
   this.debug(err);
-  this.report(err);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "doc": "jsdoc index.js -d doc/; open -a 'Google Chrome' doc/index.html",
     "lint": "jshint index.js",
-    "unit": "lab -v -c -a code test/*",
+    "unit": "lab -v -c -a code",
     "test": "npm run lint && npm run unit"
   },
   "repository": {
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/Runnable/error-cat",
   "dependencies": {
-    "101": "^0.16.1",
+    "101": "^0.18.0",
     "auto-debug": "^1.0.1",
     "boom": "^2.7.1",
     "rollbar": "^0.5.3"

--- a/test/error-cat.js
+++ b/test/error-cat.js
@@ -130,7 +130,7 @@ describe('ErrorCat', function() {
       done();
     });
 
-    it('should create a new boom error, not send to rollbar', function(done) {
+    it('should create a new boom error', function(done) {
       var code = 400;
       var message = 'Error Message';
       var data = { key: 'value' };


### PR DESCRIPTION
Thinking about this, it would be a breaking change...

Instead of the `.create` method causing the error to be reported, I created an additional method `.createAndReport` that creates the error and reports it. This prevents other errors that you may _not_ want to report to be created normally, and doesn't have a weird hack with `{ report: false }` in the data object that we would have to look for and make a decision (what if someone wants a field called `report`?!).

/cc @tjmehta @anandkumarpatel
