### PR TITLE
Add support for the level param

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,11 @@ ErrorCat.prototype.report = function (err, req, cb) {
   }
   // rollbar.handleErrorWithPayloadData usage:
   //   https://github.com/rollbar/node_rollbar/blob/a03b3a6e6e0a2734e2657cbf41e21927003f505d/lib/notifier.js#L359
-  rollbar.handleErrorWithPayloadData(err, { custom: (err.data || {}) }, req, cb);
+  var payload = {
+    level: err.level || 'error',
+    custom: err.data || {}
+  };
+  rollbar.handleErrorWithPayloadData(err, payload, req, cb);
 };
 
 /**

--- a/test/error-cat.js
+++ b/test/error-cat.js
@@ -440,7 +440,7 @@ describe('ErrorCat', function() {
       var err = new Error();
       err.data = { some: 'data' };
       error.report(err);
-      var expected = { custom: err.data };
+      var expected = { level: 'error', custom: err.data };
       expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
         .to.deep.equal(expected);
       done();
@@ -449,7 +449,14 @@ describe('ErrorCat', function() {
     it('should give empty data when none was provided', function(done) {
       error.report({});
       expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
-        .to.deep.equal({ custom: {} });
+        .to.deep.equal({ level: 'error', custom: {} });
+      done();
+    });
+
+    it('should set level if provided', function(done) {
+      error.report({ level: 'warning' });
+      expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
+        .to.deep.equal({ level: 'warning', custom: {} });
       done();
     });
 

--- a/test/error-cat.js
+++ b/test/error-cat.js
@@ -454,9 +454,19 @@ describe('ErrorCat', function() {
     });
 
     it('should set level if provided', function(done) {
-      error.report({ level: 'warning' });
+      var testError = new Error('Some message');
+      testError.level = 'warning';
+      error.report(testError);
       expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
         .to.deep.equal({ level: 'warning', custom: {} });
+      done();
+    });
+
+    it('should use `error` as default level', function(done) {
+      var testError = new Error('Some message');
+      error.report(testError);
+      expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
+        .to.deep.equal({ level: 'error', custom: {} });
       done();
     });
 


### PR DESCRIPTION
error object passed to error cat can have `level` now.
https://rollbar.com/docs/notifier/node_rollbar/
