### PR TITLE
CriticalError

### DIFF
--- a/lib/errors/critical-error.js
+++ b/lib/errors/critical-error.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const BaseError = require('./base-error')
+
+/**
+ * Error to be thrown or passed when an application encounters a critical/fatal
+ * error.
+ * @class
+ * @extends error-cat:errors~BaseError
+ * @author Ryan Sandor Richards
+ */
+module.exports = class CriticalError extends BaseError {
+  /**
+   * Creates a new critical error.
+   * @param {String} message Message for the error.
+   * @param {Object} data Additional data for the error to be given to rollbar.
+   */
+  constructor (message, data) {
+    super(message, data)
+    this.setLevel('critical')
+  }
+}

--- a/test/errors/critical-error.js
+++ b/test/errors/critical-error.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const describe = lab.describe
+const it = lab.test
+const expect = require('code').expect
+
+const CriticalError = require('../../lib/errors/critical-error')
+
+describe('errors', () => {
+  describe('CriticalError', () => {
+    describe('constructor', () => {
+      it('should set the level to critical', (done) => {
+        const warning = new CriticalError('Hey there')
+        expect(warning.reporting.level).to.equal('critical')
+        done()
+      })
+    }) // end 'constructor'
+  }) // end 'CriticalError'
+}) // end 'errors'


### PR DESCRIPTION
Added a new error class: `CriticalError` which sets the reporting level to `critical` by default.
- [x] @podviaznikov 
