### PR TITLE
Initialize Reporters

### DIFF
--- a/lib/error-cat.js
+++ b/lib/error-cat.js
@@ -35,6 +35,7 @@ class ErrorCat {
    */
   setReporter (reporter) {
     this.reporter = reporter
+    reporter.initialize()
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "error-cat",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A friendly feline companion that helps you create, track, and report errors.",
   "main": "index.js",
   "directories": {

--- a/test/error-cat.js
+++ b/test/error-cat.js
@@ -9,10 +9,12 @@ const expect = require('code').expect
 const sinon = require('sinon')
 
 const ErrorCat = require('../lib/error-cat')
+const noop = require('101/noop')
 const RollbarReporter = require('../lib/rollbar-reporter')
 
 describe('ErrorCat', () => {
   var cat
+  const reporter = { initialize: noop }
 
   beforeEach((done) => {
     cat = new ErrorCat()
@@ -43,7 +45,6 @@ describe('ErrorCat', () => {
 
     describe('given reporter', () => {
       it('should use the given reporter', (done) => {
-        const reporter = { my: 'reporter' }
         const errorCat = new ErrorCat(reporter)
         expect(errorCat.reporter).to.equal(reporter)
         done()
@@ -53,8 +54,15 @@ describe('ErrorCat', () => {
 
   describe('setReporter', () => {
     it('should set the reporter', (done) => {
-      cat.setReporter('food')
-      expect(cat.reporter).to.equal('food')
+      cat.setReporter(reporter)
+      expect(cat.reporter).to.equal(reporter)
+      done()
+    })
+
+    it('should initialize the reporter', (done) => {
+      const reporter = { initialize: sinon.stub() }
+      cat.setReporter(reporter)
+      expect(reporter.initialize.calledOnce).to.be.true()
       done()
     })
   }) // end 'setReporter'


### PR DESCRIPTION
Reporters must be initialized before they are set to the error-cat instance to ensure any setup has been done before using them (such as connecting 3rd party clients, etc.)
- [x] @podviaznikov 
