### PR TITLE
Fix Fingerprint

### DIFF
--- a/lib/rollbar-reporter.js
+++ b/lib/rollbar-reporter.js
@@ -4,6 +4,7 @@ const AbstractReporter = require('./abstract-reporter')
 const envIs = require('101/env-is')
 const exists = require('101/exists')
 const isFunction = require('101/is-function')
+const isString = require('101/is-string')
 const rollbar = require('rollbar')
 
 /**
@@ -64,11 +65,20 @@ class RollbarReporter extends AbstractReporter {
 
     // Report the error
     const custom = err.data || {}
-    rollbar.handleErrorWithPayloadData(err, {
+    var fingerprint = this.getFingerprint(err)
+    var payload = {
       level: this.getLevel(err),
-      fingerprint: this.getFingerprint(err),
       custom: custom
-    }, custom.req, cb)
+    }
+
+    if (fingerprint) {
+      if (!isString(fingerprint)) {
+        fingerprint = JSON.stringify(fingerprint)
+      }
+      payload.fingerprint = fingerprint
+    }
+
+    rollbar.handleErrorWithPayloadData(err, payload, custom.req, cb)
   }
 }
 

--- a/test/rollbar-reporter.js
+++ b/test/rollbar-reporter.js
@@ -197,11 +197,48 @@ describe('RollbarReporter', () => {
           expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
             .to.deep.equal({
               level: 'error',
-              fingerprint: null,
               custom: {}
             })
+          done()
         })
-        done()
+      })
+
+      it('should add fingerprint when present', (done) => {
+        const error = {
+          message: 'sucka',
+          reporting: {
+            fingerprint: 'whoooodoggy'
+          }
+        }
+        reporter.report(error, () => {
+          expect(rollbar.handleErrorWithPayloadData.calledOnce).to.be.true()
+          expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
+            .to.deep.equal({
+              level: 'error',
+              fingerprint: error.reporting.fingerprint,
+              custom: {}
+            })
+          done()
+        })
+      })
+
+      it('should stringify non-string fingerprints', (done) => {
+        const error = {
+          message: 'sucka',
+          reporting: {
+            fingerprint: {foo: 'bar'}
+          }
+        }
+        reporter.report(error, () => {
+          expect(rollbar.handleErrorWithPayloadData.calledOnce).to.be.true()
+          expect(rollbar.handleErrorWithPayloadData.firstCall.args[1])
+            .to.deep.equal({
+              level: 'error',
+              fingerprint: JSON.stringify(error.reporting.fingerprint),
+              custom: {}
+            })
+          done()
+        })
       })
     })
   }) // end 'report'


### PR DESCRIPTION
Rollbar loses its mind if you send a non-string `fingerprint` (including null). This fixes the issue.
- [x] @bkendall 
