### PR TITLE
Add reporting as optional param

### DIFF
--- a/lib/errors/base-error.js
+++ b/lib/errors/base-error.js
@@ -2,6 +2,7 @@
 
 const ExtendableError = require('es6-error')
 const isObject = require('101/is-object')
+const pick = require('101/pick')
 
 /**
  * Extendable base class that includes additional information that effects the
@@ -22,7 +23,7 @@ module.exports = class BaseError extends ExtendableError {
   constructor (message, data, reporting) {
     super(message)
     this.data = isObject(data) ? data : {}
-    this.reporting = reporting || {}
+    this.reporting = pick(reporting || {}, [ 'level', 'fingerprint' ])
   }
 
   /**

--- a/lib/errors/base-error.js
+++ b/lib/errors/base-error.js
@@ -15,11 +15,14 @@ module.exports = class BaseError extends ExtendableError {
    * Creates a new base error.
    * @param {String} message Message for the error.
    * @param {Object} data Additional data for the error to be given to rollbar.
+   * @param {Object} reporting Optional reporting configuration object
+   * @param {String} reporting.level optional reporting level
+   * @param {String} reporting.fingerprint optional reporting fingerprint
    */
-  constructor (message, data) {
+  constructor (message, data, reporting) {
     super(message)
     this.data = isObject(data) ? data : {}
-    this.reporting = {}
+    this.reporting = reporting || {}
   }
 
   /**

--- a/lib/errors/worker-error.js
+++ b/lib/errors/worker-error.js
@@ -13,11 +13,14 @@ module.exports = class WorkerError extends BaseError {
    * Creates a new worker error.
    * @param {String} message Message for the error.
    * @param {Object} data Additional data for the error to be given to rollbar.
+   * @param {Object} reporting Optional reporting configuration object.
+   * @param {String} reporting.level optional reporting level.
+   * @param {String} reporting.fingerprint optional reporting fingerprint.
    * @param {String} queue Name of the queue for the worker.
    * @param {Object} job The job that was being processed.
    */
-  constructor (message, data, queue, job) {
-    super(message, data)
+  constructor (message, data, reporting, queue, job) {
+    super(message, data, reporting)
     this.setQueue(queue)
     this.setJob(job)
   }

--- a/lib/errors/worker-warning.js
+++ b/lib/errors/worker-warning.js
@@ -14,11 +14,14 @@ module.exports = class WorkerWarning extends WorkerError {
    * of warning unless explicitly overriden after instantiation.
    * @param {string} message Message for the warning.
    * @param {object} data Additional data for the warning.
+   * @param {Object} reporting Optional reporting configuration object.
+   * @param {String} reporting.level optional reporting level.
+   * @param {String} reporting.fingerprint optional reporting fingerprint.
    * @param {string} Name of the queue.
    * @param {object} job Job that caused the warning.
    */
-  constructor (message, data, queue, job) {
-    super(message, data, queue, job)
+  constructor (message, data, reporting, queue, job) {
+    super(message, data, reporting, queue, job)
     this.setLevel('warn')
   }
 }

--- a/test/errors/base-error.js
+++ b/test/errors/base-error.js
@@ -30,6 +30,15 @@ describe('errors', () => {
         done()
       })
 
+      it('should set reporting', (done) => {
+        const reporting = {
+          level: 'new-level'
+        }
+        const error = new BaseError('wowie', {}, reporting)
+        expect(error.reporting).to.deep.equal(reporting)
+        done()
+      })
+
       it('should set a blank reporting member', (done) => {
         const error = new BaseError('wowie')
         expect(error.reporting).to.deep.equal({})

--- a/test/errors/worker-error.js
+++ b/test/errors/worker-error.js
@@ -26,9 +26,18 @@ describe('errors', () => {
         done()
       })
 
+      it('should set the reporting', (done) => {
+        const reporting = {
+          level: 'new-level'
+        }
+        const error = new WorkerError('', {}, reporting)
+        expect(error.reporting).to.equal(reporting)
+        done()
+      })
+
       it('should set the queue name', (done) => {
         const queue = 'neat:stuff'
-        const error = new WorkerError('', {}, queue)
+        const error = new WorkerError('', {}, {}, queue)
         expect(WorkerError.prototype.setQueue.calledWith(queue)).to.be.true()
         expect(error.data.queue).to.equal(queue)
         done()
@@ -36,7 +45,7 @@ describe('errors', () => {
 
       it('should set the job', (done) => {
         const job = { type: 'neat:stuff' }
-        const error = new WorkerError('', {}, '', job)
+        const error = new WorkerError('', {}, {}, '', job)
         expect(WorkerError.prototype.setJob.calledWith(job)).to.be.true()
         expect(error.data.job).to.deep.equal(job)
         done()

--- a/test/errors/worker-error.js
+++ b/test/errors/worker-error.js
@@ -28,10 +28,24 @@ describe('errors', () => {
 
       it('should set the reporting', (done) => {
         const reporting = {
-          level: 'new-level'
+          level: 'new-level',
+          fingerprint: 'new-fingerprint'
         }
         const error = new WorkerError('', {}, reporting)
-        expect(error.reporting).to.equal(reporting)
+        expect(error.reporting).to.deep.equal(reporting)
+        done()
+      })
+
+      it('should pass only allowed reporting fields', (done) => {
+        const reporting = {
+          level: 'new-level',
+          fingerprint: 'new-fingerprint',
+          customer: 'Runnable'
+        }
+        const error = new WorkerError('', {}, reporting)
+        expect(error.reporting).to.not.deep.equal(reporting)
+        delete reporting.customer
+        expect(error.reporting).to.deep.equal(reporting)
         done()
       })
 


### PR DESCRIPTION
It seems that it might still be breaking change. I'm not 100% sure fi someone used old constructors for `WorkerErrors` but seems that since signature changed we must release it as breaking change.
